### PR TITLE
Run with preset AWS environment secrets

### DIFF
--- a/lib/utils/aws.js
+++ b/lib/utils/aws.js
@@ -1,14 +1,10 @@
-const execa = require('execa');
 const path = require('path');
 const awsRegions = require('aws-regions');
 const { getBinPath } = require('./env');
 const { logOperation } = require('./');
 
 function runAWSCommand(cmd, args) {
-  return execa(getBinPath('awsudo'), [
-    '-u',
-    process.env.AWS_PROFILE,
-    getBinPath('aws'),
+  return runCommandWithAWSCredentials('aws', [
     cmd,
     ...args
   ]);

--- a/lib/utils/aws.js
+++ b/lib/utils/aws.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const awsRegions = require('aws-regions');
-const { getBinPath } = require('./env');
+const { getBinPath, runCommandWithAWSCredentials } = require('./env');
 const { logOperation } = require('./');
 
 function runAWSCommand(cmd, args) {

--- a/lib/utils/env.js
+++ b/lib/utils/env.js
@@ -58,7 +58,7 @@ exports.checkEnvironment = async () => {
   await installRequirements();
 };
 
-runCommandWithAWSCredentials = function(cmd, args) {
+exports.runCommandWithAWSCredentials = (cmd, args) => {
   if (envAWSKeysExist()) {
     return execa(getBinPath(cmd), [
       ...args
@@ -72,7 +72,6 @@ runCommandWithAWSCredentials = function(cmd, args) {
     ]);
   }
 }
-exports.runCommandWithAWSCredentials = runCommandWithAWSCredentials;
 
 exports.getBinPath = getBinPath;
 

--- a/lib/utils/env.js
+++ b/lib/utils/env.js
@@ -12,7 +12,7 @@ const getBinPath = bin => path.join(__dirname, '../../.env/bin', bin);
 
 const envAWSKeysExist = function() {
   const { AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = process.env;
-  return AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY
+  return AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY;
 }
 
 const installEnvironment = async () => {

--- a/lib/utils/env.js
+++ b/lib/utils/env.js
@@ -6,8 +6,14 @@ const chalk = require('chalk');
 const { runCommand, logOperation, showError } = require('./');
 const { deploymentManifestSchema } = require('./schemas');
 const { checkForUpdates } = require('./update');
+const execa = require('execa');
 
 const getBinPath = bin => path.join(__dirname, '../../.env/bin', bin);
+
+const envAWSKeysExist = function() {
+  const { AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = process.env;
+  return AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY
+}
 
 const installEnvironment = async () => {
   if (await fs.pathExists(path.join(__dirname, '../../.env'))) {
@@ -23,6 +29,10 @@ const installEnvironment = async () => {
 };
 
 const installRequirements = async () => {
+  if (envAWSKeysExist()) {
+    logOperation('AWS API key environment variables is set, `awsudo` not needed.');
+    return;
+  }
   if (await fs.pathExists(getBinPath('awsudo'))) {
     logOperation('`awsudo` exists, skipping installation.');
     return;
@@ -37,9 +47,9 @@ const installRequirements = async () => {
 };
 
 exports.checkEnvironment = async () => {
-  if (!process.env.AWS_PROFILE) {
+  if (!process.env.AWS_PROFILE && !envAWSKeysExist()) {
     return showError(
-      'You have to set `AWS_PROFILE` environment variable before continuing. Visit https://docs.cxcloud.com for help.'
+      'Some environment variables has to be set before running cxcloud. Visit https://docs.cxcloud.com for help.'
     );
   }
 
@@ -47,6 +57,22 @@ exports.checkEnvironment = async () => {
   await installEnvironment();
   await installRequirements();
 };
+
+runCommandWithAWSCredentials = function(cmd, args) {
+  if (envAWSKeysExist()) {
+    return execa(getBinPath(cmd), [
+      ...args
+    ]);
+  } else {
+    return execa(getBinPath('awsudo'), [
+      '-u',
+      process.env.AWS_PROFILE,
+      getBinPath(cmd),
+      ...args
+    ]);
+  }
+}
+exports.runCommandWithAWSCredentials = runCommandWithAWSCredentials;
 
 exports.getBinPath = getBinPath;
 

--- a/lib/utils/kops.js
+++ b/lib/utils/kops.js
@@ -1,4 +1,3 @@
-const execa = require('execa');
 const ora = require('ora');
 const fs = require('fs-extra');
 const path = require('path');
@@ -6,10 +5,7 @@ const { getBinPath } = require('./env');
 const { logOperation, sleep } = require('./');
 
 function runKopsCommand(cmd, args) {
-  return execa(getBinPath('awsudo'), [
-    '-u',
-    process.env.AWS_PROFILE,
-    'kops',
+  return runCommandWithAWSCredentials('kops', [
     cmd,
     ...args
   ]);

--- a/lib/utils/kops.js
+++ b/lib/utils/kops.js
@@ -1,7 +1,7 @@
 const ora = require('ora');
 const fs = require('fs-extra');
 const path = require('path');
-const { getBinPath } = require('./env');
+const { getBinPath, runCommandWithAWSCredentials } = require('./env');
 const { logOperation, sleep } = require('./');
 
 function runKopsCommand(cmd, args) {

--- a/lib/utils/terraform.js
+++ b/lib/utils/terraform.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { getBinPath } = require('./env');
+const { getBinPath, runCommandWithAWSCredentials } = require('./env');
 const { copyTpl } = require('./fs');
 const { logOperation } = require('./');
 

--- a/lib/utils/terraform.js
+++ b/lib/utils/terraform.js
@@ -1,14 +1,10 @@
 const path = require('path');
-const execa = require('execa');
 const { getBinPath } = require('./env');
 const { copyTpl } = require('./fs');
 const { logOperation } = require('./');
 
 function runTerraformCommand(cmd, args = []) {
-  const child = execa(getBinPath('awsudo'), [
-    '-u',
-    process.env.AWS_PROFILE,
-    'terraform',
+  child = runCommandWithAWSCredentials('terraform', [
     cmd,
     ...args
   ]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cxcloud",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "CXCloud command line tools",
   "license": "MIT",
   "repository": "cxcloud/cxcloud-cli",


### PR DESCRIPTION
Added possibility to run cxcloud-cli with environment variables already set. Awsudo will not be installed or used in case the environment variables has already been set.

This is needed in case similar software like awsudo is used. E.g. [aws-vault](https://github.com/99designs/aws-vault) can store the secrets in macOS Keychain without the need to expose secrets in `~/.aws/credentials`