### PR TITLE
Allow configuring env variables from ConfigMaps

### DIFF
--- a/lib/utils/schemas.js
+++ b/lib/utils/schemas.js
@@ -17,6 +17,11 @@ const environmentVariableValueRefSchema = Joi.object().keys({
     name: Joi.string().required(),
     key: Joi.string()
   })
+}).keys({
+  configMapKeyRef: Joi.object().keys({
+    name: Joi.string().required(),
+    key: Joi.string()
+  })
 });
 
 const environmentVariableSchema = Joi.object()


### PR DESCRIPTION
For example:

```
  env:
    - name: ENV
      valueFrom:
        configMapKeyRef:
          name: configmap
          key: env
```